### PR TITLE
Repo doesn't include lunr.min.js since v2.0.1

### DIFF
--- a/source/guides/getting_started.html.md
+++ b/source/guides/getting_started.html.md
@@ -18,7 +18,7 @@ $ npm install -g lunr
 Lunr is also available as a single file for use in browsers using script tags. It can be included from the unpkg CDN like this:
 
 ```html
-  <script src="https://unpkg.com/lunr/lunr.min.js"></script>
+  <script src="https://unpkg.com/lunr/lunr.js"></script>
 ```
 
 The following examples will use node.js for simplicity; the same code will work in any JavaScript environment.


### PR DESCRIPTION
lunr.min.js isn't included in the repo since olivernn/lunr.js@2a57c5334f2df69c8d41bceae1e5b6c66502342d, and unpkg CDN serves whatever comes from npm - so the linked https://unpkg.com/lunr/lunr.min.js doesn't work as of https://unpkg.com/lunr@2.0.1/lunr.min.js (it worked for https://unpkg.com/lunr@2.0.0/lunr.min.js somehow).

I _think_ the **real** issue is - you _should_ distribute the minified version, too. But I'm not sure why/how that changed.