### PR TITLE
Fix usage of .join()

### DIFF
--- a/source/guides/index_prebuilding.html.md
+++ b/source/guides/index_prebuilding.html.md
@@ -37,7 +37,7 @@ stdin.on('data', function (data) {
 })
 
 stdin.on('end', function () {
-  var documents = JSON.parse(buffer.join())
+  var documents = JSON.parse(buffer.join(''))
 
   var idx = lunr(function () {
     this.ref('id')


### PR DESCRIPTION
In the sample node script for building an Index, var `documents = JSON.parse(buffer.join())` is used to parse STDIN to a JSON array. However, this does not work for large inputs (i.e., in case the buffer has more than one element), because if called without arguments, join() will join the array elements with a comma separator, resulting in invalid JSON. So, correct is: `var documents = JSON.parse(buffer.join(''))`