### PR TITLE
Remove global install flag

### DIFF
--- a/source/guides/getting_started.html.md
+++ b/source/guides/getting_started.html.md
@@ -12,7 +12,7 @@ This guide will walk you through setting up your first search index with Lunr. I
 Install Lunr with npm:
 
 ```shell
-$ npm install -g lunr
+$ npm install lunr
 ```
 
 Lunr is also available as a single file for use in browsers using script tags. It can be included from the unpkg CDN like this:


### PR DESCRIPTION
These docs have `lunr` installed globally, but I think that may be incorrect? I'm not seeing any cli commands as part of the `lunr` package